### PR TITLE
Potential fix for code scanning alert no. 4: Code injection

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -87,7 +87,6 @@ jobs:
     - name: Handle sub-issue creation requests
       if: contains(github.event.comment.body, '/create-sub-issues')
       run: |
-        comment_body="${{ github.event.comment.body }}"
         issue_number="${{ github.event.issue.number }}"
         
         # Extract sub-issue information from comment
@@ -108,3 +107,4 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        comment_body: ${{ github.event.comment.body }}


### PR DESCRIPTION
Potential fix for [https://github.com/d-oit/gh-sub-issues/security/code-scanning/4](https://github.com/d-oit/gh-sub-issues/security/code-scanning/4)

To fix the code injection vulnerability, we should pass the untrusted input (`github.event.comment.body`) to the shell script via an environment variable, and then use shell-native variable expansion (`$comment_body`) in the script. Specifically, in the step "Handle sub-issue creation requests", move the assignment of `comment_body` from the shell script to the `env:` section of the step. In the script, reference `$comment_body` as a shell variable. This prevents code injection because the shell will treat the value as a literal string, not as code to be executed.

**Required changes:**
- In the step at line 87-110, move the assignment of `comment_body` from the script to the `env:` section.
- In the script, reference `$comment_body` instead of assigning it.
- Ensure all usages of `$comment_body` are properly quoted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
